### PR TITLE
Fix path on windows

### DIFF
--- a/lib/Doctrine/Deprecations/Deprecation.php
+++ b/lib/Doctrine/Deprecations/Deprecation.php
@@ -138,7 +138,7 @@ class Deprecation
 
         // first check that the caller is not from a tests folder, in which case we always let deprecations pass
         if (isset($backtrace[1]['file'], $backtrace[0]['file']) && strpos($backtrace[1]['file'], DIRECTORY_SEPARATOR . 'tests' . DIRECTORY_SEPARATOR) === false) {
-            $path = DIRECTORY_SEPARATOR . 'vendor' . DIRECTORY_SEPARATOR . $package . DIRECTORY_SEPARATOR;
+            $path = DIRECTORY_SEPARATOR . 'vendor' . DIRECTORY_SEPARATOR . str_replace("/", DIRECTORY_SEPARATOR, $package) . DIRECTORY_SEPARATOR;
 
             if (strpos($backtrace[0]['file'], $path) === false) {
                 return;

--- a/lib/Doctrine/Deprecations/Deprecation.php
+++ b/lib/Doctrine/Deprecations/Deprecation.php
@@ -11,6 +11,7 @@ use function array_reduce;
 use function assert;
 use function debug_backtrace;
 use function sprintf;
+use function str_replace;
 use function strpos;
 use function strrpos;
 use function substr;
@@ -138,7 +139,7 @@ class Deprecation
 
         // first check that the caller is not from a tests folder, in which case we always let deprecations pass
         if (isset($backtrace[1]['file'], $backtrace[0]['file']) && strpos($backtrace[1]['file'], DIRECTORY_SEPARATOR . 'tests' . DIRECTORY_SEPARATOR) === false) {
-            $path = DIRECTORY_SEPARATOR . 'vendor' . DIRECTORY_SEPARATOR . str_replace("/", DIRECTORY_SEPARATOR, $package) . DIRECTORY_SEPARATOR;
+            $path = DIRECTORY_SEPARATOR . 'vendor' . DIRECTORY_SEPARATOR . str_replace('/', DIRECTORY_SEPARATOR, $package) . DIRECTORY_SEPARATOR;
 
             if (strpos($backtrace[0]['file'], $path) === false) {
                 return;

--- a/tests/Doctrine/Deprecations/DeprecationTest.php
+++ b/tests/Doctrine/Deprecations/DeprecationTest.php
@@ -234,6 +234,8 @@ class DeprecationTest extends TestCase
         );
 
         Foo::triggerDependencyWithDeprecation();
+
+        $this->assertEquals(1, Deprecation::getUniqueTriggeredDeprecationsCount());
     }
 
     public function testDeprecationIfCalledFromOutsideNotTriggeringFromInside(): void


### PR DESCRIPTION
While running my project test suite on Windows (local env) and linux (CI env) I could notice that I have a deprecation raised on Linux that is not on Windows.

```
Indirect deprecation triggered by MyControllerTest::testDelete:
#27 53.01 AbstractPlatform::supportsForeignKeyConstraints() is deprecated. (AbstractPlatform.php:4093 called by JoinedSubclassPersister.php:254,
https://github.com/doctrine/dbal/pull/5409, package doctrine/dbal)
#27 53.01 Stack trace:
#27 53.01 #0 [internal function]: Symfony\Bridge\PhpUnit\DeprecationErrorHandler->handleError(16384, '...', '...', 217)
#27 53.01 #1 vendor/doctrine/dbal/src/Platforms/AbstractPlatform.php(4093): Doctrine\Deprecations\Deprecation::triggerIfCalledFromOutside('...',
'...', '...')
#27 53.01 #2 vendor/doctrine/orm/lib/Doctrine/ORM/Persisters/Entity/JoinedSubclassPersister.php(254): Doctrine\DBAL\Platforms\AbstractPlatform->s
upportsForeignKeyConstraints()
#27 53.01 #3 vendor/doctrine/orm/lib/Doctrine/ORM/UnitOfWork.php(1296): Doctrine\ORM\Persisters\Entity\JoinedSubclassPersister->delete(Object(...))
```


When the path is created on Windows using the package name (ex.: ``doctrine/dbal``) it results as ``\vendor\doctrine/dbal\`` but the real path to the library coming from ``$backtrace[1]['function']`` is ``...\vendor\doctrine\dbal\src\Platforms\AbstractPlatform.php`` so currently it match the following condition on windows while it's not the case on Linux.

```php
if (strpos($backtrace[0]['file'], $path) === false) {
    return;
}
```

After, that been say, I'm not sure if it's normal that I got the deprecation as it's raised from a call to the deprecated method ``supportsForeignKeyConstraints()`` of [AbstractPlatform ](https://github.com/doctrine/dbal/blob/3.6.x/src/Platforms/AbstractPlatform.php) of the ``doctrine/dbal`` package done from the ``delete`` method of ``vendor/doctrine/orm/lib/Doctrine/ORM/Persisters/Entity/JoinedSubclassPersister.php``.